### PR TITLE
Fix reading of health mode status

### DIFF
--- a/acer-wmi-battery.c
+++ b/acer-wmi-battery.c
@@ -231,6 +231,7 @@ static ssize_t health_mode_store(struct device_driver *driver, const char *buf,
 		return err;
 
 	set_battery_health_control(HEALTH_MODE, param_val);
+	update_state();
 
 	return count;
 }


### PR DESCRIPTION
Discuss about this in issue#14, and the patch was tested reading/writing healthmode using sysfs.
https://github.com/frederik-h/acer-wmi-battery/issues/14#issuecomment-1465355110