### PR TITLE
Update readme: recommend git package and use "sudo" commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,20 +34,20 @@ Loading the module without any parameters does not
 change any health or calibration mode settings of your system:
 
 ```
-insmod acer-wmi-battery.ko
+sudo insmod acer-wmi-battery.ko
 ```
 
 ### Health mode
 
 The charge limit can then be enabled as follows:
 ```
-echo 1 > /sys/bus/wmi/drivers/acer-wmi-battery/health_mode
+echo 1 | sudo tee /sys/bus/wmi/drivers/acer-wmi-battery/health_mode
 ```
 
 Alternatively, you can enable it at module initialization
 time:
 ```
-insmod acer-wmi-battery.ko enable_health_mode=1
+sudo insmod acer-wmi-battery.ko enable_health_mode=1
 ```
 
 ### Calibration mode
@@ -56,7 +56,7 @@ Before attempting the battery calibration, connect
 your laptop to a power supply. The calibration mode
 can be started as follows:
 ```
-echo 1 > /sys/bus/wmi/drivers/acer-wmi-battery/calibration_mode
+echo 1 | sudo tee /sys/bus/wmi/drivers/acer-wmi-battery/calibration_mode
 ```
 
 
@@ -69,7 +69,7 @@ the calibration mode should be manually disabled
 since the WMI event that indicates the completion
 of the calibration is not yet handled by the module:
 ```
-echo 0 > /sys/bus/wmi/drivers/acer-wmi-battery/calibration_mode
+echo 0 | sudo tee /sys/bus/wmi/drivers/acer-wmi-battery/calibration_mode
 ```
 
 ### Related work

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Make sure that you have the kernel headers for your kernel installed
 and type `make` in the cloned project directory. In more detail,
 on a Debian or Ubuntu system, you can build by:
 ```
-sudo apt install build-essential linux-headers-$(uname -r)
+sudo apt install build-essential linux-headers-$(uname -r) git
 git clone https://github.com/frederik-h/acer-wmi-battery.git
 cd acer-wmi-battery
 make


### PR DESCRIPTION
1) On Ubuntu 22.04 "git" package is not pre-installed and "build-essential" don't install it   
2) build instruction recommends "sudo" but other commands work mostly only for a root user mode (involves usage  or sudo -s or root account).  
Let's use "sudo" commands everywhere (most distros prefer it anyway) to simplify life for less experienced users.