### PR TITLE
Add support for reading the battery temperature

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ provides through the Acer Care Center on Windows: a health mode that
 limits the battery charge to 80% with the goal of preserving your
 battery's capacity and a battery calibration mode which puts your
 battery through a controlled charge-discharge cycle to provide more
-accurate battery capacity estimates.
+accurate battery capacity estimates. It can also be used to read the
+battery temperature.
 
 So far the driver has been reported to work on an Acer Swift 3
 (SF314-34), an [Acer Aspire 5 A515-45G-R5A1](https://github.com/linrunner/TLP/issues/596#issuecomment-1146784888),
@@ -59,7 +60,6 @@ can be started as follows:
 echo 1 | sudo tee /sys/bus/wmi/drivers/acer-wmi-battery/calibration_mode
 ```
 
-
 The calibration disables health mode and charges
 to 100%. Then it discharges and recharges the battery
 once. This can take a long time and for accurate
@@ -70,6 +70,13 @@ since the WMI event that indicates the completion
 of the calibration is not yet handled by the module:
 ```
 echo 0 | sudo tee /sys/bus/wmi/drivers/acer-wmi-battery/calibration_mode
+```
+
+### Battery Temperature
+
+The temperature of the battery in millidegree Celsius can be read as follows:
+```
+cat /sys/bus/wmi/drivers/acer-wmi-battery/temperature
 ```
 
 ### Related work


### PR DESCRIPTION
The battery temperature is available using WMI method 19. The data provided by this WMI method seems to be closely related with the "Smart Battery Data Speification" available at https://sbs-forum.org/specs/sbdat110.pdf.

The code was tested on a Acer Aspire E1-731.