### PR TITLE
Add Nitro 5 AN515-57 to supported models

### DIFF
--- a/MODELS.md
+++ b/MODELS.md
@@ -16,6 +16,7 @@ Users have reported that the driver works on the following Acer laptops:
 - Enduro N3 Urban (EUN314A-51W) https://github.com/frederik-h/acer-wmi-battery/issues/4
 - Nitro 5
   - AN515-44 https://github.com/frederik-h/acer-wmi-battery/issues/77
+  - AN515-57 https://github.com/frederik-h/acer-wmi-battery/issues/88
   - AN515-58 https://github.com/frederik-h/acer-wmi-battery/issues/57
   - AN517-54 https://github.com/frederik-h/acer-wmi-battery/issues/59
 - Nitro ANV15-51 https://github.com/frederik-h/acer-wmi-battery/issues/71


### PR DESCRIPTION
Have not tested the calibration mode, but the battery limit works perfectly.

I am on NixOS so installation is a bit different. I will open another PR that adds instructions on how to install this kernel module into a NixOS system.