### PR TITLE
Added documentation for NixOS installation

### DIFF
--- a/MODELS.md
+++ b/MODELS.md
@@ -16,6 +16,7 @@ Users have reported that the driver works on the following Acer laptops:
 - Enduro N3 Urban (EUN314A-51W) https://github.com/frederik-h/acer-wmi-battery/issues/4
 - Nitro 5
   - AN515-44 https://github.com/frederik-h/acer-wmi-battery/issues/77
+  - AN515-57 https://github.com/frederik-h/acer-wmi-battery/issues/88
   - AN515-58 https://github.com/frederik-h/acer-wmi-battery/issues/57
   - AN517-54 https://github.com/frederik-h/acer-wmi-battery/issues/59
 - Nitro ANV15-51 https://github.com/frederik-h/acer-wmi-battery/issues/71

--- a/MODELS.md
+++ b/MODELS.md
@@ -16,7 +16,6 @@ Users have reported that the driver works on the following Acer laptops:
 - Enduro N3 Urban (EUN314A-51W) https://github.com/frederik-h/acer-wmi-battery/issues/4
 - Nitro 5
   - AN515-44 https://github.com/frederik-h/acer-wmi-battery/issues/77
-  - AN515-57 https://github.com/frederik-h/acer-wmi-battery/issues/88
   - AN515-58 https://github.com/frederik-h/acer-wmi-battery/issues/57
   - AN517-54 https://github.com/frederik-h/acer-wmi-battery/issues/59
 - Nitro ANV15-51 https://github.com/frederik-h/acer-wmi-battery/issues/71

--- a/NIX_INSTALL.md
+++ b/NIX_INSTALL.md
@@ -1,0 +1,95 @@
+# NixOS Installation
+
+If you're on NixOS, add the following code snippet to a file named
+`acer-wmi-battery.nix`:
+
+```nix
+{
+  stdenv,
+  lib,
+  kernel,
+  fetchgit,
+}:
+stdenv.mkDerivation {
+  pname = "acer-wmi-battery";
+  version = "${kernel.modDirVersion}";
+
+  src = fetchgit {
+    url = "https://github.com/frederik-h/acer-wmi-battery";
+    branchName = "main";
+    sha256 = lib.fakeHash; # REPLACE THIS AFTER FAILING SYSTEM REBUILD
+  };
+
+  hardeningDisable = ["pic" "format"];
+  nativeBuildInputs = kernel.moduleBuildDependencies;
+
+  buildPhase = ''
+    make -C ${kernel.dev}/lib/modules/${kernel.modDirVersion}/build \
+         M=$(pwd) \
+         modules
+  '';
+  cleanPhase = ''
+    make -C ${kernel.dev}/lib/modules/${kernel.modDirVersion}/build \
+         M=$(pwd) \
+         clean
+  '';
+  installPhase = ''
+    mkdir -p $out/lib/modules/${kernel.modDirVersion}
+    cp -r *.ko $out/lib/modules/${kernel.modDirVersion}/
+  '';
+
+  meta = {
+    description = "A kernel module for setting Acer device battery settings";
+    homepage = "https://github.com/frederik-h/acer-wmi-battery";
+    license = lib.licenses.gpl2;
+    maintainers = ["Frederik Harwath"];
+    platforms = lib.platforms.linux;
+  };
+}
+```
+
+To install the kernel module into your system, add the following snippet to
+your `configuration.nix` or another module that is imported into your
+system configuration:
+
+```nix
+boot.extraModulePackages = [(config.boot.kernelPackages.callPackage ./path/to/acer-wmi-battery.nix {})];
+
+boot.kernelModules = ["acer-wmi-battery"];
+```
+
+where `./path/to/acer-wmi-battery.nix` is the path to the Nix file
+described above. Make sure the arguments of the module that you put this
+snippet in contains the `config` argument. The first line of the module
+(like `configuration.nix`) should something look like:
+
+```nix
+{config, ...}: {
+```
+
+When rebuilding your system with something like `nixos-rebuild switch`, the
+build will fail and tell you which hash you should use in the
+`acer-wmi-battery.nix` file. For example:
+
+```
+specified: sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
+got:       sha256-mI6Ob9BmNfwqT3nndWf3jkz8f7tV10odkTnfApsNo+A=
+```
+
+To fix this, replace `lib.fakeHash` in the `acer-wmi-battery.nix` file with
+the hash after "got: " in the error message you receive, with surrounding
+quotation marks.
+
+## Setting kernel options declaratively
+
+The following snippet shows an example for setting kernel options
+declaratively in your configuration:
+
+```nix
+# (Optionally) set options immediately
+boot.extraModprobeConfig = ''
+  options acer-wmi-battery enable_health_mode=1
+'';
+```
+
+See [README.md](./README.md) for option references.

--- a/README.md
+++ b/README.md
@@ -29,6 +29,11 @@ cd acer-wmi-battery
 make
 ```
 
+### NixOS
+
+See [NIX_INSTALL.md](./NIX_INSTALL.md) for instructions to install
+this kernel module in NixOS.
+
 ## Using
 
 Loading the module without any parameters does not


### PR DESCRIPTION
This PR will not modify the Makefile or source code. It simply adds a new file that contains instructions on how to install this kernel module on NixOS, as that can be quite cumbersome for custom modules not available in [Nixpkgs](https://search.nixos.org/packages). README.md is altered slightly so it refers to the new file for interested users.

I have tested this on my own NixOS system, in which it works perfectly. The instructions given are as general as possible, so it should work on any other NixOS system.